### PR TITLE
initial 1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
   host:
     - python >=3.9
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.9
     - numpy
@@ -31,10 +33,23 @@ test:
     - pip
 
 about:
-  home: https://data-apis.org/array-api-strict/
+  home: https://github.com/data-apis/array-api-strict
   summary: A strict, minimal implementation of the Python array API standard.
+  description: |
+    array_api_strict is a strict, minimal implementation of the Python array API.
+    The purpose of array-api-strict is to provide an implementation of the array API 
+    for consuming libraries to test against so they can be completely sure their usage 
+    of the array API is portable.
+    It is not intended to be used by end-users. End-users of the array API should just 
+    use their favorite array library (NumPy, CuPy, PyTorch, etc.) as usual. 
+    It is also not intended to be used as a dependency by consuming libraries. 
+    Consuming library code should use the array-api-compat package to support the array API. 
+    Rather, it is intended to be used in the test suites of consuming libraries to test their array API usage.
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
+  dev_url: https://github.com/data-apis/array-api-strict
+  doc_url: https://github.com/data-apis/array-api-strict
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changes:
- initial release
- keeping as noarch. It will be used as a test dependency.

https://github.com/data-apis/array-api-strict/tree/1.1