### PR TITLE
update to 2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "array-api-strict" %}
-{% set version = "1.1" %}
+{% set version = "2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/array_api_strict-{{ version }}.tar.gz
-  sha256: 8172ff23d1865d4129b16e3da1d6846bf33474c996cc252bbb13305cdf6ede59
+  sha256: 2f36091d6a5931bbe75db42374d278097cf7d7f3402a55620eccb6a0e3f9f723
 
 build:
   noarch: python


### PR DESCRIPTION
array-api-strict 2.1

**Destination channel:** main

### Links

- https://anaconda.atlassian.net/browse/PKG-6015
- [[Upstream repository]()](https://github.com/data-apis/array-api-strict)

