### PR TITLE
Version 2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: a4d2ef41cc994e716045439bed8c46e82a4dcaf17a1309a2c97c772f6c276c31
 
 build:
+  # This stays as noarch as it's a test dependency: https://github.com/AnacondaRecipes/array-api-strict-feedstock/pull/2#discussion_r1819058071
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
@@ -52,6 +53,8 @@ about:
   doc_url: https://github.com/data-apis/array-api-strict
 
 extra:
+  skip-lints:
+    - avoid_noarch
   recipe-maintainers:
     - asmeurer
     - rgommers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,16 +13,17 @@ build:
   # This stays as noarch as it's a test dependency: https://github.com/AnacondaRecipes/array-api-strict-feedstock/pull/2#discussion_r1819058071
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<39]
   number: 0
 
 requirements:
   host:
-    - python >=3.9
+    - python
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.9
+    - python
     - numpy
 
 test:
@@ -50,7 +51,7 @@ about:
   license_family: BSD
   license_file: LICENSE
   dev_url: https://github.com/data-apis/array-api-strict
-  doc_url: https://github.com/data-apis/array-api-strict
+  doc_url: https://data-apis.org/array-api-strict/
 
 extra:
   skip-lints:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,17 +13,16 @@ build:
   # This stays as noarch as it's a test dependency: https://github.com/AnacondaRecipes/array-api-strict-feedstock/pull/2#discussion_r1819058071
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<39]
   number: 0
 
 requirements:
   host:
-    - python
+    - python >=3.9
     - pip
     - setuptools
     - wheel
   run:
-    - python
+    - python >=3.9
     - numpy
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "array-api-strict" %}
-{% set version = "2.1" %}
+{% set version = "2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/array_api_strict-{{ version }}.tar.gz
-  sha256: 2f36091d6a5931bbe75db42374d278097cf7d7f3402a55620eccb6a0e3f9f723
+  sha256: a4d2ef41cc994e716045439bed8c46e82a4dcaf17a1309a2c97c772f6c276c31
 
 build:
   noarch: python


### PR DESCRIPTION
array-api-strict 2.2 

**Destination channel:**  defaults

### Links

- [PKG-6555](https://anaconda.atlassian.net/browse/PKG-6555) 
- [Upstream repository](https://github.com/data-apis/array-api-strict)
- [Upstream changelog/diff](https://github.com/data-apis/array-api-strict/compare/2.1...2.2)
- Relevant dependency PRs:
  - ...

### Explanation of changes:
- version and sha


[PKG-6555]: https://anaconda.atlassian.net/browse/PKG-6555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ