### PR TITLE
array-api-strict 2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 /build_artifacts
 
 *.pyc
+# Cursor temporary files
+/.cursor/tmp/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "array-api-strict" %}
-{% set version = "2.2" %}
+{% set version = "2.4" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/array_api_strict-{{ version }}.tar.gz
-  sha256: a4d2ef41cc994e716045439bed8c46e82a4dcaf17a1309a2c97c772f6c276c31
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/array_api_strict-{{ version }}.tar.gz
+  sha256: 7a0d5a0622a5479d6ffe6ef8ce09e7e4337fdf4cce5f52a89727c11a499a1367
 
 build:
   # This stays as noarch as it's a test dependency: https://github.com/AnacondaRecipes/array-api-strict-feedstock/pull/2#discussion_r1819058071
@@ -17,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python >=3.10
     - pip
-    - setuptools
-    - wheel
+    - setuptools >=61.0,<=75
+    - setuptools_scm >8
   run:
-    - python >=3.9
+    - python >=3.10
     - numpy
 
 test:


### PR DESCRIPTION
array-api-strict 2.4 (to test scipy)

https://github.com/data-apis/array-api-strict/blob/2.4/pyproject.toml